### PR TITLE
Updated meter definitions files

### DIFF
--- a/resources/modbus_dbo_maps/PM5111.json
+++ b/resources/modbus_dbo_maps/PM5111.json
@@ -222,5 +222,65 @@
         "number_of_registers": 2,
         "format": "float32",
         "units": "Hertz"
+    },
+    "21330": {
+        "dbo_name": "line1_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21332": {
+        "dbo_name": "line2_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21334": {
+        "dbo_name": "line3_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21322": {
+        "dbo_name": "line1_line2_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21324": {
+        "dbo_name": "line2_line3_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21326": {
+        "dbo_name": "line1_line3_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21300": {
+        "dbo_name": "line1_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21302": {
+        "dbo_name": "line2_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21304": {
+        "dbo_name": "line3_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21306": {
+        "dbo_name": "neutral_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
     }
 }

--- a/resources/modbus_dbo_maps/PM5561.json
+++ b/resources/modbus_dbo_maps/PM5561.json
@@ -222,5 +222,65 @@
         "number_of_registers": 2,
         "format": "float32",
         "units": "Hertz"
+    },
+    "21330": {
+        "dbo_name": "line1_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21332": {
+        "dbo_name": "line2_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21334": {
+        "dbo_name": "line3_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21322": {
+        "dbo_name": "line1_line2_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21324": {
+        "dbo_name": "line2_line3_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21326": {
+        "dbo_name": "line1_line3_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21300": {
+        "dbo_name": "line1_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21302": {
+        "dbo_name": "line2_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21304": {
+        "dbo_name": "line3_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21306": {
+        "dbo_name": "neutral_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
     }
 }

--- a/resources/modbus_dbo_maps/PM8240.json
+++ b/resources/modbus_dbo_maps/PM8240.json
@@ -205,22 +205,64 @@
         "format": "float32",
         "units": "No-units"
     },
-    "3216": {
+    "2706": {
         "dbo_name": "total_energy_accumulator",
-        "number_of_registers": 4,
-        "format": "int64",
-        "units": "Watt-hours"
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "KiloWatt-hours"
     },
-    "3232": {
+    "2714": {
         "dbo_name": "total_reactive_energy_accumulator",
-        "number_of_registers": 4,
-        "format": "int64",
-        "units": "Volt-amperes-reactive-hours"
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "KiloVolt-amperes-reactive-hours"
     },
     "3110": {
         "dbo_name": "frequency_sensor",
         "number_of_registers": 2,
         "format": "float32",
         "units": "Hertz"
+    },
+    "21330": {
+        "dbo_name": "line1_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21332": {
+        "dbo_name": "line2_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21334": {
+        "dbo_name": "line3_neutral_harmonic_distortion_voltage_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21300": {
+        "dbo_name": "line1_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21302": {
+        "dbo_name": "line2_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21304": {
+        "dbo_name": "line3_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
+    },
+    "21306": {
+        "dbo_name": "neutral_harmonic_distortion_current_sensor",
+        "number_of_registers": 2,
+        "format": "float32",
+        "units": "Percent"
     }
 }

--- a/udmi_site_model/devices/EM-1/metadata.json
+++ b/udmi_site_model/devices/EM-1/metadata.json
@@ -96,6 +96,36 @@
       },
       "frequency_sensor": {
           "units": "Hertz"
+      },
+      "line1_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line2_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line3_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line1_line2_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line2_line3_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line1_line3_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line1_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "line2_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "line3_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "neutral_harmonic_distortion_current_sensor": {
+          "units": "Percent"
       }
     }
   },

--- a/udmi_site_model/devices/EM-2/metadata.json
+++ b/udmi_site_model/devices/EM-2/metadata.json
@@ -96,6 +96,36 @@
       },
       "frequency_sensor": {
           "units": "Hertz"
+      },
+      "line1_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line2_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line3_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line1_line2_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line2_line3_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line1_line3_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line1_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "line2_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "line3_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "neutral_harmonic_distortion_current_sensor": {
+          "units": "Percent"
       }
     }
   },

--- a/udmi_site_model/devices/EM-3/metadata.json
+++ b/udmi_site_model/devices/EM-3/metadata.json
@@ -89,13 +89,34 @@
           "units": "No-units"
       },
       "total_energy_accumulator": {
-          "units": "Watt-hours"
+          "units": "Kilo-Watt-hours"
       },
       "total_reactive_energy_accumulator": {
-          "units": "Volt-amperes-reactive-hours"
+          "units": "Kilo-Volt-amperes-reactive-hours"
       },
       "frequency_sensor": {
           "units": "Hertz"
+      },
+      "line1_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line2_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line3_neutral_harmonic_distortion_voltage_sensor": {
+          "units": "Percent"
+      },
+      "line1_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "line2_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "line3_harmonic_distortion_current_sensor": {
+          "units": "Percent"
+      },
+      "neutral_harmonic_distortion_current_sensor": {
+          "units": "Percent"
       }
     }
   },


### PR DESCRIPTION
Measurement definitions are updated according to latest DBO Names document, current as of 8/8/2024. Further changes to EM-3: some register addresses changed, also unit to energy accumulators changed from Wh --> kWh and VARh --> kVARh